### PR TITLE
Fix test context config

### DIFF
--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,8 +1,4 @@
 spring:
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
   data:
     mongodb:
       host: localhost


### PR DESCRIPTION
## Summary
- remove disabling of datasource autoconfiguration in test `application.yml`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_685f650abcf8832b98908e28f93387ca