### PR TITLE
Fix reverse geocode endpoint mismatch

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -121,7 +121,8 @@ export const mapApi = {
   },
   // 逆地理编码
   reverseGeocode: (location: Location) => {
-    return get<ResponseData<{ address: string }>>('/api/map/reverse-geocode', location)
+    // 与后端 MapController 保持一致的路由名稱為 /regeocode
+    return get<ResponseData<{ address: string }>>('/api/map/regeocode', location)
   }
 }
 


### PR DESCRIPTION
## Summary
- align reverse geocode API endpoint with backend

## Testing
- `npm run build` *(fails: vue-tsc permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_685f4a5a58f8832b92744cf63bb21e07