### PR TITLE
Add cancelled order status

### DIFF
--- a/backend/src/main/java/com/example/logistics/entity/Order.java
+++ b/backend/src/main/java/com/example/logistics/entity/Order.java
@@ -57,6 +57,7 @@ public class Order {
     public enum OrderStatus {
         已揽件,
         运输中,
-        已签收
+        已签收,
+        已取消
     }
-} 
+}


### PR DESCRIPTION
## Summary
- support `已取消` order status in backend enum

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685f4d524de8832b99ee8fccd39a4f1d