### PR TITLE
Fix caching path and add test

### DIFF
--- a/backend/src/main/java/com/example/logistics/service/impl/OrderServiceImpl.java
+++ b/backend/src/main/java/com/example/logistics/service/impl/OrderServiceImpl.java
@@ -9,6 +9,7 @@ import com.example.logistics.repository.UserRepository;
 import com.example.logistics.service.NotificationService;
 import com.example.logistics.service.OrderService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Lazy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -27,6 +28,8 @@ public class OrderServiceImpl implements OrderService {
     private final UserRepository userRepository;
     private final CourierRepository courierRepository;
     private final NotificationService notificationService;
+    @Lazy
+    private final OrderService orderService;
 
     @Override
     @Transactional
@@ -80,7 +83,7 @@ public class OrderServiceImpl implements OrderService {
     @Transactional
     @CacheEvict(value = "orders", key = "#orderId")
     public Order updateOrderStatus(Long orderId, Order.OrderStatus status) {
-        Order order = getOrderById(orderId);
+        Order order = orderService.getOrderById(orderId);
         Order.OrderStatus oldStatus = order.getStatus();
         order.setStatus(status);
         order.setUpdatedTime(LocalDateTime.now());

--- a/backend/src/test/java/com/example/logisticssystem/OrderServiceCachingTest.java
+++ b/backend/src/test/java/com/example/logisticssystem/OrderServiceCachingTest.java
@@ -1,0 +1,51 @@
+package com.example.logisticssystem;
+
+import com.example.logistics.LogisticsSystemApplication;
+import com.example.logistics.entity.Order;
+import com.example.logistics.repository.CourierRepository;
+import com.example.logistics.repository.OrderRepository;
+import com.example.logistics.repository.UserRepository;
+import com.example.logistics.service.NotificationService;
+import com.example.logistics.service.OrderService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.annotation.EnableCaching;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest(classes = LogisticsSystemApplication.class)
+@EnableCaching
+class OrderServiceCachingTest {
+
+    @MockBean
+    private OrderRepository orderRepository;
+    @MockBean
+    private UserRepository userRepository;
+    @MockBean
+    private CourierRepository courierRepository;
+    @MockBean
+    private NotificationService notificationService;
+
+    @Autowired
+    private OrderService orderService;
+
+    @Test
+    void getOrderByIdUsesCache() {
+        Order order = new Order();
+        order.setId(1L);
+        Mockito.when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+        Order first = orderService.getOrderById(1L);
+        Order second = orderService.getOrderById(1L);
+
+        assertSame(first, second);
+        verify(orderRepository, times(1)).findById(1L);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `OrderServiceImpl.updateOrderStatus` invokes `getOrderById` via the Spring proxy so caching works
- add a unit test verifying repeated calls to `getOrderById` use the cache

## Testing
- `mvn test` *(fails: Could not resolve dependencies from `maven.aliyun.com`)*

------
https://chatgpt.com/codex/tasks/task_e_685f56baa464832b9afb7ec745039090