### PR TITLE
Fix reverse geocode API path

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -121,7 +121,7 @@ export const mapApi = {
   },
   // 逆地理编码
   reverseGeocode: (location: Location) => {
-    return get<ResponseData<{ address: string }>>('/api/map/reverse-geocode', location)
+    return get<ResponseData<{ address: string }>>('/api/map/regeocode', location)
   }
 }
 


### PR DESCRIPTION
## Summary
- update map API reverse geocode endpoint to `/api/map/regeocode`

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f56b87e90832b863dee82be66cffe